### PR TITLE
Wrapped migrations with tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ deps:
 up:
 	@vagrant up --no-provision
 	@vagrant provision 
-	@alembic upgrade head
+	@tox -e db_up
 	
 test:
 	@tox

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,14 @@ downloadcache = {toxworkdir}/_download
 commands =
     python setup.py testr --coverage --testr-args='{posargs}'
 
+[testenv:db_down]
+commands =
+    alembic downgrade base
+
+[testenv:db_up]
+commands =
+    alembic upgrade head
+
 [testenv:docs]
 commands =
     python setup.py build_sphinx

--- a/vagrant/site.yml
+++ b/vagrant/site.yml
@@ -30,8 +30,3 @@
         - libpq-dev
         - git
     - pip: name=tox
-    # TODO(retr0h): Temporary - should remove
-    - pip: requirements=/vagrant/{{ item }}
-      with_items:
-        - requirements.txt
-        - test-requirements.txt


### PR DESCRIPTION
I can never remember the name `alembic`.  Also, allows us to remove
some ansible bootstrap, since everything runs in the tox provided
venv.