### PR TITLE
Renamed pool_name to namespace

### DIFF
--- a/alembic/versions/2b1b42252b23_create_ipv4_address_table.py
+++ b/alembic/versions/2b1b42252b23_create_ipv4_address_table.py
@@ -19,14 +19,14 @@ def upgrade():
     op.create_table(
         'ipv4_address',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('pool_name', sa.String(25), nullable=False),
-        sa.Column('pool_cidr', postgresql.CIDR, nullable=False),
+        sa.Column('namespace', sa.String(25), nullable=False),
+        sa.Column('cidr', postgresql.CIDR, nullable=False),
         sa.Column('address', postgresql.INET, nullable=False),
         sa.Column('allocated', sa.Boolean, server_default='0'),
         # getconf HOST_NAME_MAX
         sa.Column('hostname', sa.String(64)),
 
-        sa.UniqueConstraint('pool_name', 'hostname', name='uix_1')
+        sa.UniqueConstraint('namespace', 'hostname', name='uix_1')
     )
 
 

--- a/demeter/address.py
+++ b/demeter/address.py
@@ -73,7 +73,7 @@ class Address(object):
         else:
             raise NetworkNotAllowedException
 
-    def allocate(self, pool_name, cidr):
+    def allocate(self, namespace, cidr):
         """
         Populate the database with addresses from the given cidr.  Returns True
         on success, otherwise the called functions raise.
@@ -81,15 +81,15 @@ class Address(object):
         TODO: Need to filter the cidr with rules (e.g. network, broadcast,
         addresses).
 
-        :param pool_name: A string containing the name to call the cidr.
+        :param namespace: A string containing the namespace to nest the cidr.
         :param cidr: A string containing the CIDR to validate.
         """
         ip_network = self._valid_network(cidr)
         if ip_network:
             if self._allowed_network(ip_network):
                 for ip in ip_network:
-                    ia = Ipv4Address(pool_name=pool_name,
-                                     pool_cidr=cidr,
+                    ia = Ipv4Address(namespace=namespace,
+                                     cidr=cidr,
                                      address=str(ip))
                     self._session.add(ia)
                 self._session.commit()

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -66,11 +66,11 @@ class TestAddress(unittest.TestCase):
     @unpack
     def test_allocate(self, value, expected):
         cidr = '192.168.2.0/{0}'.format(value)
-        pool_name = 'test_pool_{0}'.format(value)
-        self._address.allocate(pool_name, cidr)
+        namespace = 'test_namespace_{0}'.format(value)
+        self._address.allocate(namespace, cidr)
 
         results = self._session.query(Ipv4Address).filter(
-            Ipv4Address.pool_name == pool_name).all()
+            Ipv4Address.namespace == namespace).all()
 
         self.assertEquals(expected, len(results))
 
@@ -78,10 +78,10 @@ class TestAddress(unittest.TestCase):
         cidr = '192.0.2.0/36'
 
         with self.assertRaises(Address.InvalidNetworkException):
-            self._address.allocate('test_pool', cidr)
+            self._address.allocate('test_namespace', cidr)
 
     def test_allocate_raises_with_address_(self):
         cidr = '192.0.2.0/22'
 
         with self.assertRaises(Address.NetworkNotAllowedException):
-            self._address.allocate('test_pool', cidr)
+            self._address.allocate('test_namespace', cidr)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,8 +38,8 @@ class TestModels(unittest.TestCase):
 
     @data(
         ('id', 'INTEGER', 'False'),
-        ('pool_name', 'VARCHAR(25)', 'False'),
-        ('pool_cidr', 'CIDR', 'False'),
+        ('namespace', 'VARCHAR(25)', 'False'),
+        ('cidr', 'CIDR', 'False'),
         ('address', 'INET', 'False'),
         ('allocated', 'BOOLEAN', 'True'),
         ('hostname', 'VARCHAR(64)', 'True'),
@@ -52,9 +52,9 @@ class TestModels(unittest.TestCase):
                 self.assertEquals(type, str(column.get('type')))
                 self.assertEquals(nullable, str(column.get('nullable')))
 
-    def test_ipv4_address_has_hostname_to_pool_name_uniq_costraint(self):
+    def test_ipv4_address_has_hostname_to_namespace_uniq_costraint(self):
         constraints = self._inspector.get_unique_constraints('ipv4_address')
         constraint = constraints[0].get('column_names')
-        expected = ['pool_name', 'hostname']
+        expected = ['namespace', 'hostname']
 
         self.assertEquals(expected, constraint)


### PR DESCRIPTION
Don't think we really need to name the pool.  We just define a namespace
for the cidr to live in.  The hostname and cidr will be unique to the
namespace.