### PR TITLE
Each test should cleanup after itself

### DIFF
--- a/alembic/versions/2b1b42252b23_create_ipv4_addresses_and_namespaces_table.py
+++ b/alembic/versions/2b1b42252b23_create_ipv4_addresses_and_namespaces_table.py
@@ -19,7 +19,7 @@ def upgrade():
     op.create_table(
         'namespaces',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('name', sa.String(16), nullable=False),
+        sa.Column('name', sa.String(36), nullable=False),
 
         sa.UniqueConstraint('name', name='name_uix'),
     )

--- a/demeter/address.py
+++ b/demeter/address.py
@@ -43,12 +43,10 @@ class Address(object):
                 session.add(addr)
                 return addr
 
-    def delete_all(self):
-        """ Performs a cascading delete """
+    def delete(self, address):
         with demeter.transactional_session() as session:
-            addresses = session.query(models.Ipv4Address).all()
-            for address in addresses:
-                session.delete(address)
+            session.delete(address)
+            return True
 
     def find_by_ns_and_cidr(self, ns_name, cidr):
         with demeter.temp_session() as session:

--- a/demeter/namespace.py
+++ b/demeter/namespace.py
@@ -32,15 +32,10 @@ class Namespace(object):
                 session.add(ns)
                 return ns
 
-    def delete_all(self):
-        """ Delete namespaces which do not have parents. """
+    def delete(self, ns):
         with demeter.transactional_session() as session:
-            namespaces = session.query(models.Namespace).all()
-            for namespace in namespaces:
-                try:
-                    namespace.address.cidr
-                except AttributeError:
-                    session.delete(namespace)
+            session.delete(ns)
+            return True
 
     def delete_by_name(self, name):
         result = self.find_by_name(name)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,7 @@ class TestModels(unittest.TestCase):
 
     @data(
         ('namespaces', 'id', 'INTEGER', 'False'),
-        ('namespaces', 'name', 'VARCHAR(16)', 'False'),
+        ('namespaces', 'name', 'VARCHAR(36)', 'False'),
         ('ipv4_addresses', 'id', 'INTEGER', 'False'),
         ('ipv4_addresses', 'cidr', 'CIDR', 'False'),
         ('ipv4_addresses', 'address', 'INET', 'False'),

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -20,72 +20,64 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import uuid
+
 from ddt import data
 from ddt import ddt
-from ddt import unpack
 import unittest2 as unittest
 
-from demeter import Address
 from demeter import Namespace
 
 
 @ddt
 class TestNamespace(unittest.TestCase):
     def setUp(self):
-        self._address = Address.Address()
         self._namespace = Namespace.Namespace()
-        self._namespace.delete_all()
 
-    @data('test-namespace')
+    @data(str(uuid.uuid4()))
     def test_create(self, name):
-        self._namespace.create(name)
+        ns = self._namespace.create(name)
 
         result = self._namespace.find_by_name(name)
-        self.assertEquals('test-namespace', result.name)
+        self.assertEquals(name, result.name)
 
-    @unpack
-    @data(
-        ('test-namespace', 'test-parentless', '198.51.100.0/24',
-         '198.51.100.1', 'test-hostname')
-    )
-    # @data('test-namespace')
-    def test_delete_all_removes_orphans(self,
-                                        ns_name,
-                                        ns_parentless,
-                                        cidr,
-                                        address,
-                                        hostname):
-        self._namespace.create(ns_name)
-        self._namespace.create(ns_parentless)
-        self._address.create(cidr, address, hostname, ns_name)
+        self._namespace.delete(ns)
 
-        self._namespace.delete_all()
+    @data(str(uuid.uuid4()))
+    def test_delete(self, name):
+        ns = self._namespace.create(name)
 
-        result = self._namespace.find_by_name(ns_parentless)
-        assert not result
-        result = self._namespace.find_by_name(ns_name)
+        result = self._namespace.delete(ns)
         assert result
+        result = self._namespace.find_by_name(name)
+        assert not result
 
-    @data('test-namespace')
+        self._namespace.delete(ns)
+
+    @data(str(uuid.uuid4()))
     def test_delete_by_name(self, name):
-        self._namespace.create(name)
+        ns = self._namespace.create(name)
 
         result = self._namespace.delete_by_name(name)
         assert result
 
-    @data('invalid')
+        self._namespace.delete(ns)
+
+    @data('ns-not-found')
     def test_delete_by_name_is_false_when_not_found(self, name):
         result = self._namespace.delete_by_name(name)
         assert not result
 
-    @data('test-namespace')
+    @data(str(uuid.uuid4()))
     def test_find_by_name(self, name):
-        self._namespace.create(name)
+        ns = self._namespace.create(name)
 
         result = self._namespace.find_by_name(name)
-        self.assertEquals('test-namespace', result.name)
+        self.assertEquals(name, result.name)
 
-    @data('invalid')
+        self._namespace.delete(ns)
+
+    @data('ns-not-found')
     def test_find_by_name_is_false_when_not_found(self, name):
         result = self._namespace.find_by_name(name)
         assert not result


### PR DESCRIPTION
Rather than having a delete_all called in setUp(), each test should
delete what it created.  This is useful when dealing with testr, and
multiple tests running at the same time.  Also, using a uuid based
namespace name in tests to help with simultaneous testing.