### PR TITLE
Moved cidr to namespace

### DIFF
--- a/alembic/versions/2b1b42252b23_create_ipv4_addresses_and_namespaces_table.py
+++ b/alembic/versions/2b1b42252b23_create_ipv4_addresses_and_namespaces_table.py
@@ -20,6 +20,7 @@ def upgrade():
         'namespaces',
         sa.Column('id', sa.Integer, primary_key=True),
         sa.Column('name', sa.String(36), nullable=False),
+        sa.Column('cidr', postgresql.CIDR, nullable=False),
 
         sa.UniqueConstraint('name', name='name_uix'),
     )
@@ -27,10 +28,8 @@ def upgrade():
     op.create_table(
         'ipv4_addresses',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('cidr', postgresql.CIDR, nullable=False),
         sa.Column('address', postgresql.INET, nullable=False),
         sa.Column('address_int', sa.Numeric(10), nullable=False),
-        sa.Column('allocated', sa.Boolean, server_default='0'),
         # getconf HOST_NAME_MAX
         sa.Column('hostname', sa.String(64)),
         sa.Column('namespace_id',

--- a/demeter/address.py
+++ b/demeter/address.py
@@ -61,12 +61,10 @@ class Address(object):
         with demeter.temp_session() as session:
             ns = models.Namespace
             query = session.query(ns).join(ns.addresses).filter(
-                ns.name == ns_name).all()
-            # TODO(retr0h): should move this elsewhere?
-            cidr = query[0].addresses[0].cidr
+                ns.name == ns_name).first()
             allocated_address_list = [int(a.address_int)
-                                      for a in query[0].addresses]
-            available_address_set = self._compare(self._cidr_list(cidr),
+                                      for a in query.addresses]
+            available_address_set = self._compare(self._cidr_list(query.cidr),
                                                   allocated_address_list)
             return self._next(available_address_set)
 

--- a/demeter/namespace.py
+++ b/demeter/namespace.py
@@ -22,12 +22,17 @@
 
 import demeter
 from demeter import models
+from demeter.address import Address
 
 
 class Namespace(object):
-    def create(self, name):
+    def __init__(self):
+        self._address = Address()
+
+    def create(self, name, cidr):
+        self._address._allowed_network(cidr)
         if not self.find_by_name(name):
-            ns = models.Namespace(name=name)
+            ns = models.Namespace(name=name, cidr=cidr)
             with demeter.transactional_session() as session:
                 session.add(ns)
                 return ns

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -35,27 +35,23 @@ from demeter.namespace import Namespace
 
 @ddt
 class TestAddress(unittest.TestCase):
-    def addr_data():
+    def address_data():
         ns_name = str(uuid.uuid4())
-        cidr = '198.51.100.0/24'
-        address = '198.51.100.1'
-        address_int = 3325256705
         hostname = 'test-{0}'.format(ns_name)
 
-        return (ns_name, {'cidr': cidr,
-                          'address': address,
-                          'address_int': address_int,
-                          'hostname': hostname})
+        return (ns_name, '198.51.100.0/24', {'address': '198.51.100.1',
+                                             'address_int': 3325256705,
+                                             'hostname': hostname})
 
     def setUp(self):
         self._address = Address()
         self._namespace = Namespace()
 
     @unpack
-    @data(addr_data())
-    def test_create_when_namespace_exists(self, ns_name, values):
+    @data(address_data())
+    def test_create_when_namespace_exists(self, ns_name, cidr, values):
         address = values.get('address')
-        ns = self._namespace.create(ns_name)
+        ns = self._namespace.create(ns_name, cidr)
         values.update({'namespace': ns})
         self._address.create(**values)
 
@@ -65,17 +61,20 @@ class TestAddress(unittest.TestCase):
         self._namespace.delete(ns)
 
     @unpack
-    @data(addr_data())
-    def test_create_false_when_namespace_not_found(self, ns_name, values):
+    @data(address_data())
+    def test_create_false_when_namespace_not_found(self,
+                                                   ns_name,
+                                                   cidr,
+                                                   values):
         values.update({'namespace': None})
         result = self._address.create(**values)
         assert not result
 
     @unpack
-    @data(addr_data())
-    def test_delete_cascades(self, ns_name, values):
+    @data(address_data())
+    def test_delete_cascades(self, ns_name, cidr, values):
         address = values.get('address')
-        ns = self._namespace.create(ns_name)
+        ns = self._namespace.create(ns_name, cidr)
         values.update({'namespace': ns})
         self._address.create(**values)
         self._namespace.delete(ns)
@@ -86,10 +85,10 @@ class TestAddress(unittest.TestCase):
         assert not result
 
     @unpack
-    @data(addr_data())
-    def test_find_by_ns_and_address(self, ns_name, values):
+    @data(address_data())
+    def test_find_by_ns_and_address(self, ns_name, cidr, values):
         address = values.get('address')
-        ns = self._namespace.create(ns_name)
+        ns = self._namespace.create(ns_name, cidr)
         values.update({'namespace': ns})
         self._address.create(**values)
 
@@ -107,9 +106,9 @@ class TestAddress(unittest.TestCase):
         assert not result
 
     @unpack
-    @data(addr_data())
-    def test_next_one(self, ns_name, values):
-        ns = self._namespace.create(ns_name)
+    @data(address_data())
+    def test_next_one(self, ns_name, cidr, values):
+        ns = self._namespace.create(ns_name, cidr)
         values.update({'namespace': ns})
         self._address.create(**values)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,11 +38,10 @@ class TestModels(unittest.TestCase):
     @data(
         ('namespaces', 'id', 'INTEGER', 'False'),
         ('namespaces', 'name', 'VARCHAR(36)', 'False'),
+        ('namespaces', 'cidr', 'CIDR', 'False'),
         ('ipv4_addresses', 'id', 'INTEGER', 'False'),
-        ('ipv4_addresses', 'cidr', 'CIDR', 'False'),
         ('ipv4_addresses', 'address', 'INET', 'False'),
         ('ipv4_addresses', 'address_int', 'NUMERIC(10, 0)', 'False'),
-        ('ipv4_addresses', 'allocated', 'BOOLEAN', 'True'),
         ('ipv4_addresses', 'hostname', 'VARCHAR(64)', 'True'),
     )
     @unpack


### PR DESCRIPTION
We should track cidr through the namespace association.  Allows us to perform
validation sooner.